### PR TITLE
Hostname missing in getopts

### DIFF
--- a/install_mfsbsd_iso.sh
+++ b/install_mfsbsd_iso.sh
@@ -88,7 +88,7 @@ usage() {
 	EOF
 }
 
-while getopts "a:hvi:m:p:s:" flags; do
+while getopts "a:hvi:H:m:p:s:" flags; do
 	case "${flags}" in
 	a)
 		ISO_HASH="${OPTARG}"

--- a/install_mfsbsd_iso.sh
+++ b/install_mfsbsd_iso.sh
@@ -104,6 +104,9 @@ while getopts "a:hvi:m:p:s:" flags; do
 	i)
 		INTERFACE="$INTERFACE ${OPTARG}"
 		;;
+	H)
+		HOSTNAME="${OPTARG}"
+		;;
 	m)
 		MFSBSDISO="${OPTARG}"
 		;;


### PR DESCRIPTION
```
{
  "changed": true,
  "cmd": "bash install_mfsbsd_iso.sh  -m 'https://mfsbsd.vx.sk/files/iso/13/amd64/mfsbsd-13.1-RELEASE-amd64.iso' -a '128ad6b7cc8cb0f163e293d570136e93' -H 'mfsbsd-hetzner' -p 'beastiROCKZ' -i 'em0' -s '90'  > /dev/null",
  "delta": "0:00:00.005828",
  "end": "2022-10-25 19:09:25.614699",
  "msg": "non-zero return code",
  "rc": 1,
  "start": "2022-10-25 19:09:25.608871",
  "stderr": "install_mfsbsd_iso.sh: illegal option -- H\nUsage: install_mfsbsd_iso.sh [-hv] [-m url_iso -a md5_iso] [-H your_hostname] [-i network_iface] [-p 'myPassW0rD'] [-s need_free_space]\n\n  -a :  Md5 checksum rescue ISO\n  -h    Show help\n  -H    Set the hostname of the host. The default value is 'YOURHOSTNAME'.\n  -v    Show version\n  -i    Use a specific network interface if the machine has more than one.\n        By default, a network interfaces is em0.\n  -m :  URL of mfsbsd image (defaults to image on https://mfsbsd.vx.sk)\n        For example, ISO https://mfsbsd.vx.sk/files/iso/13/amd64/mfsbsd-13.1-RELEASE-amd64.iso.\n        Some ISO images do not have ssh key access, so be aware of the risks.\n  -p :  The user password to set in the Rescue ISO.\n        By default, MfsBSD's password is 'mfsroot'.\n  -s :  How much more do you need to check the availability of free disk space.\n        Supported suffixes are 'M' for MiB (by default) and 'G' for GiB.",
  "stderr_lines": [
    "install_mfsbsd_iso.sh: illegal option -- H",
    "Usage: install_mfsbsd_iso.sh [-hv] [-m url_iso -a md5_iso] [-H your_hostname] [-i network_iface] [-p 'myPassW0rD'] [-s need_free_space]",
    "",
    "  -a :  Md5 checksum rescue ISO",
    "  -h    Show help",
    "  -H    Set the hostname of the host. The default value is 'YOURHOSTNAME'.",
    "  -v    Show version",
    "  -i    Use a specific network interface if the machine has more than one.",
    "        By default, a network interfaces is em0.",
    "  -m :  URL of mfsbsd image (defaults to image on https://mfsbsd.vx.sk)",
    "        For example, ISO https://mfsbsd.vx.sk/files/iso/13/amd64/mfsbsd-13.1-RELEASE-amd64.iso.",
    "        Some ISO images do not have ssh key access, so be aware of the risks.",
    "  -p :  The user password to set in the Rescue ISO.",
    "        By default, MfsBSD's password is 'mfsroot'.",
    "  -s :  How much more do you need to check the availability of free disk space.",
    "        Supported suffixes are 'M' for MiB (by default) and 'G' for GiB."
  ],
  "stdout": "",
  "stdout_lines": []
}
```

Is what I got earlier running my playbook with your role. I think this PR fixes this. 

Thanks, for creating this role it helps me starting to setup FreeBSD on Hetzner after they remove the rescue system and learning some ansible along the way. 

Best regards

Daniel 