### PR TITLE
Add debug distribution sets installation option and fix sector size handling

### DIFF
--- a/gozfs.sh
+++ b/gozfs.sh
@@ -50,7 +50,7 @@
 
 ftphost="ftp://ftp.de.freebsd.org/pub/FreeBSD/releases/amd64/amd64/12.3-BETA3/"
 ftp_mirror_list="ftp6.ua ftp1.fr ftp2.de"
-filelist="base lib32 kernel"
+filelist="base base-dbg lib32 lib32-dbg kernel kernel-dbg"
 filelist_optional="MANIFEST"			# only fetch
 memdisknumber=10
 #iface_manual=YES
@@ -337,8 +337,10 @@ fi
 
 ###offset=$(gpart show ${ref_disk} | grep '\- free \-' | tail -n 1 | awk '{print $1}')
 last_partition_disk_size=$(gpart show ${ref_disk} | grep '\- free \-' | tail -n 1 | awk '{print $2}')
+sector_size=$(gpart list ${ref_disk} | awk '/Sectorsize:/{print $2; exit}')
+[ -z "${sector_size}" ] && sector_size=512
 if [ "${zfs_partition_size}" ] && [ "${last_partition_disk_size}" -le "${smallest_disk_size}" ]; then
-	size_string="-s $((zfs_partition_size - offset))"
+	size_string="-s $((_zfs_partition_size / sector_size - offset))"
 else
 	size_string="-s $((last_partition_disk_size - offset))"
 fi

--- a/gozfs.sh
+++ b/gozfs.sh
@@ -50,7 +50,8 @@
 
 ftphost="ftp://ftp.de.freebsd.org/pub/FreeBSD/releases/amd64/amd64/12.3-BETA3/"
 ftp_mirror_list="ftp6.ua ftp1.fr ftp2.de"
-filelist="base base-dbg lib32 lib32-dbg kernel kernel-dbg"
+filelist="base lib32 kernel"
+filelist_debug="base-dbg lib32-dbg kernel-dbg"
 filelist_optional="MANIFEST"			# only fetch
 memdisknumber=10
 #iface_manual=YES
@@ -63,17 +64,18 @@ memdisknumber=10
 usage="Usage: $0 -p <geom_provider> -s <swap_partition_size> -S <zfs_partition_size> -n <zpoolname> -f <ftphost>
 [ -m <zpool-raidmode> -d <distribution_dir> -D <destination_dir> -M <size_memory_disk> -o <offset_end_disk> -a <ashift_disk>
 -B <boot_mode> -P <new_password> -t <timezone> -k <url_ssh_key_file> -K <url_ssh_key_dir>
--z <file_zfs_skeleton> -Z <url_file_zfs_skeleton> ]
+-z <file_zfs_skeleton> -Z <url_file_zfs_skeleton> -x ]
 [ -g <gateway> [-i <iface>] -I <IP_address/mask> ]
 
-boot_mode: auto (default), bios, uefi, hybrid"
+boot_mode: auto (default), bios, uefi, hybrid
+-x: also install debug distribution sets (base-dbg, lib32-dbg, kernel-dbg)"
 
 exerr() {
 	printf '%b\n' "$*" >&2
 	exit 1
 }
 
-while getopts p:P:s:S:n:h:f:m:M:o:d:D:t:g:i:I:a:B:z:Z:k:K: arg; do
+while getopts p:P:s:S:n:h:f:m:M:o:d:D:t:g:i:I:a:B:z:Z:k:K:x arg; do
 	case ${arg} in
 	p) provider="$provider ${OPTARG}" ;;
 	P) password=${OPTARG} ;;
@@ -97,6 +99,7 @@ while getopts p:P:s:S:n:h:f:m:M:o:d:D:t:g:i:I:a:B:z:Z:k:K: arg; do
 	Z) url_file_zfs_skeleton=${OPTARG} ;;
 	k) ssh_key_file="${ssh_key_file} ${OPTARG}" ;;
 	K) ssh_key_dir="${ssh_key_dir} ${OPTARG}" ;;
+	x) install_debug=1 ;;
 	?) exerr "${usage}" ;;
 	esac
 done
@@ -123,6 +126,11 @@ fi
 									# 1 MB approximately for every full and partial 1 TB of disk capacity.
 destdir=${destdir:-/mnt}
 esp_size="800m"						# EFI System Partition size
+
+# optionally add debug distribution sets
+if [ "${install_debug}" = "1" ]; then
+	filelist="${filelist} ${filelist_debug}"
+fi
 
 # auto-detect or validate boot mode
 detect_boot_mode() {

--- a/gozfs_512b.sh
+++ b/gozfs_512b.sh
@@ -51,6 +51,7 @@
 ftphost="ftp://ftp.de.freebsd.org/pub/FreeBSD/releases/amd64/amd64/12.3-BETA3/"
 ftp_mirror_list="ftp6.ua ftp1.fr ftp2.de"
 filelist="base lib32 kernel"
+filelist_debug="base-dbg lib32-dbg kernel-dbg"
 filelist_optional="MANIFEST"			# only fetch
 memdisknumber=10
 #iface_manual=YES
@@ -63,17 +64,18 @@ memdisknumber=10
 usage="Usage: $0 -p <geom_provider> -s <swap_partition_size> -S <zfs_partition_size> -n <zpoolname> -f <ftphost>
 [ -m <zpool-raidmode> -d <distribution_dir> -D <destination_dir> -M <size_memory_disk> -o <offset_end_disk>
 -B <boot_mode> -P <new_password> -t <timezone> -k <url_ssh_key_file> -K <url_ssh_key_dir>
--z <file_zfs_skeleton> -Z <url_file_zfs_skeleton> ]
+-z <file_zfs_skeleton> -Z <url_file_zfs_skeleton> -x ]
 [ -g <gateway> [-i <iface>] -I <IP_address/mask> ]
 
-boot_mode: auto (default), bios, uefi, hybrid"
+boot_mode: auto (default), bios, uefi, hybrid
+-x: also install debug distribution sets (base-dbg, lib32-dbg, kernel-dbg)"
 
 exerr() {
 	printf '%b\n' "$*" >&2
 	exit 1
 }
 
-while getopts p:P:s:S:n:h:f:m:M:o:d:D:t:g:i:I:B:z:Z:k:K: arg; do
+while getopts p:P:s:S:n:h:f:m:M:o:d:D:t:g:i:I:B:z:Z:k:K:x arg; do
 	case ${arg} in
 	p) provider="$provider ${OPTARG}" ;;
 	P) password=${OPTARG} ;;
@@ -96,6 +98,7 @@ while getopts p:P:s:S:n:h:f:m:M:o:d:D:t:g:i:I:B:z:Z:k:K: arg; do
 	Z) url_file_zfs_skeleton=${OPTARG} ;;
 	k) ssh_key_file="${ssh_key_file} ${OPTARG}" ;;
 	K) ssh_key_dir="${ssh_key_dir} ${OPTARG}" ;;
+	x) install_debug=1 ;;
 	?) exerr "${usage}" ;;
 	esac
 done
@@ -121,6 +124,11 @@ fi
 									# 1 MB approximately for every full and partial 1 TB of disk capacity.
 destdir=${destdir:-/mnt}
 esp_size="800m"						# EFI System Partition size
+
+# optionally add debug distribution sets
+if [ "${install_debug}" = "1" ]; then
+	filelist="${filelist} ${filelist_debug}"
+fi
 
 # auto-detect or validate boot mode
 detect_boot_mode() {
@@ -335,8 +343,10 @@ fi
 
 ###offset=$(gpart show ${ref_disk} | grep '\- free \-' | tail -n 1 | awk '{print $1}')
 last_partition_disk_size=$(gpart show ${ref_disk} | grep '\- free \-' | tail -n 1 | awk '{print $2}')
+sector_size=$(gpart list ${ref_disk} | awk '/Sectorsize:/{print $2; exit}')
+[ -z "${sector_size}" ] && sector_size=512
 if [ "${zfs_partition_size}" ] && [ "${last_partition_disk_size}" -le "${smallest_disk_size}" ]; then
-	size_string="-s $((zfs_partition_size - offset))"
+	size_string="-s $((_zfs_partition_size / sector_size - offset))"
 else
 	size_string="-s $((last_partition_disk_size - offset))"
 fi


### PR DESCRIPTION
## Summary
This PR adds support for optionally installing FreeBSD debug distribution sets and fixes sector size handling in partition size calculations.

## Key Changes
- **Debug distribution sets support**: Added `-x` command-line flag to enable installation of debug packages (base-dbg, lib32-dbg, kernel-dbg)
  - New `filelist_debug` variable defines the debug distribution sets
  - Conditional logic appends debug sets to `filelist` when `-x` flag is used
  - Updated usage documentation to describe the new flag

- **Sector size handling**: Fixed ZFS partition size calculation to account for actual disk sector size
  - Added detection of sector size from disk metadata (defaults to 512 bytes if not available)
  - Modified partition size calculation to divide by sector size for proper alignment
  - Ensures correct partition sizing across disks with different sector sizes (4K native, etc.)

## Implementation Details
- The `-x` flag is a boolean option (no argument required) added to the getopts parsing
- Debug distribution sets are only added to the file list if the flag is explicitly set
- Sector size is queried using `gpart list` and extracted via awk, with a sensible 512-byte fallback
- The partition size calculation now properly converts from bytes to sectors before applying the offset

https://claude.ai/code/session_01B9sFwkWqxF8x8Px732dZ6T