### PR TITLE
gozfs*.sh: set explicit mountpoint=/tmp on zroot/tmp

### DIFF
--- a/gozfs.sh
+++ b/gozfs.sh
@@ -462,7 +462,7 @@ if [ -z "${url_file_zfs_skeleton}" ] && [ -z "${file_zfs_skeleton}" ]; then
 # /usr and /var are shared-container datasets (canmount=off)
 zfs create -o canmount=off      -o mountpoint=/usr              $poolname/usr
 zfs create -o canmount=off      -o mountpoint=/var              $poolname/var
-zfs create                      -o exec=on      -o setuid=off   $poolname/tmp
+zfs create                      -o mountpoint=/tmp              -o exec=on      -o setuid=off   $poolname/tmp
 zfs create                      -o exec=on      -o setuid=off   $poolname/usr/ports
 zfs create -o compression=off   -o exec=off     -o setuid=off   $poolname/usr/ports/distfiles
 zfs create -o compression=off   -o exec=off     -o setuid=off   $poolname/usr/ports/packages

--- a/gozfs_512b.sh
+++ b/gozfs_512b.sh
@@ -441,7 +441,7 @@ if [ -z "${url_file_zfs_skeleton}" ] && [ -z "${file_zfs_skeleton}" ]; then
 # /usr and /var are shared-container datasets (canmount=off)
 zfs create -o canmount=off      -o mountpoint=/usr              $poolname/usr
 zfs create -o canmount=off      -o mountpoint=/var              $poolname/var
-zfs create                      -o exec=on      -o setuid=off   $poolname/tmp
+zfs create                      -o mountpoint=/tmp              -o exec=on      -o setuid=off   $poolname/tmp
 zfs create                      -o exec=on      -o setuid=off   $poolname/usr/ports
 zfs create -o compression=off   -o exec=off     -o setuid=off   $poolname/usr/ports/distfiles
 zfs create -o compression=off   -o exec=off     -o setuid=off   $poolname/usr/ports/packages


### PR DESCRIPTION
With pool mountpoint=none, zroot/tmp inherited mountpoint=none and never mounted, so chmod 1777 /mnt/tmp failed with "No such file or directory". /usr and /var got explicit mountpoints already; /tmp needs the same.

https://claude.ai/code/session_01B9sFwkWqxF8x8Px732dZ6T