### PR TITLE
gozfs*.sh: point vfs.root.mountfrom at the BE dataset

### DIFF
--- a/gozfs.sh
+++ b/gozfs.sh
@@ -616,7 +616,7 @@ fi
 
 cat <<EOF >>$destdir/boot/loader.conf
 zfs_load="YES"
-vfs.root.mountfrom="zfs:$poolname"
+vfs.root.mountfrom="zfs:$poolname/ROOT/default"
 kern.geom.label.gptid.enable=0
 kern.geom.label.disk_ident.enable=0
 debug.acpi.disabled="thermal"

--- a/gozfs_512b.sh
+++ b/gozfs_512b.sh
@@ -595,7 +595,7 @@ fi
 
 cat <<EOF >>$destdir/boot/loader.conf
 zfs_load="YES"
-vfs.root.mountfrom="zfs:$poolname"
+vfs.root.mountfrom="zfs:$poolname/ROOT/default"
 kern.geom.label.gptid.enable=0
 kern.geom.label.disk_ident.enable=0
 debug.acpi.disabled="thermal"


### PR DESCRIPTION
With the new BE layout the pool root (zroot) has mountpoint=none and canmount=off and holds no files. The loader.conf line vfs.root.mountfrom="zfs:$poolname" forced the kernel to mount the empty pool root instead of zroot/ROOT/default, so /sbin/init was absent and the system panicked with "no init".

Point vfs.root.mountfrom directly at $poolname/ROOT/default. The bootfs pool property already points there; the explicit mountfrom also works with older loaders that may not honour bootfs alone.

https://claude.ai/code/session_01B9sFwkWqxF8x8Px732dZ6T