### PR TITLE
gozfs.sh: optional ZFS native encryption (-E native) + UK TODO + v1.60

### DIFF
--- a/TODO.ZFS encryption.UK.md
+++ b/TODO.ZFS encryption.UK.md
@@ -1,0 +1,113 @@
+# TODO: Підтримка шифрування ZFS
+
+## Огляд
+
+Додати підтримку шифрування дисків до інсталяційного скрипта `gozfs.sh`.
+Два підходи: GELI (рідне для FreeBSD) та рідне шифрування ZFS (OpenZFS 2.0+).
+
+## Методи шифрування
+
+### Варіант A: GELI (geom_eli)
+
+Повне шифрування диска на рівні GEOM, нижче за ZFS.
+
+**Переваги:**
+- Зріле, добре протестоване рішення у FreeBSD з версії 7.0
+- `loader.efi` / `gptzfsboot` нативно підтримують запит пароля GELI під час завантаження
+- Шифрує все, включно з метаданими ZFS
+- Працює як з BIOS, так і з UEFI завантаженням
+
+**Недоліки:**
+- Накладні витрати на продуктивність (додатковий шар GEOM)
+- Неможливо використовувати ZFS send/recv для зашифрованих даних (розшифровуються на рівні GEOM)
+- Управління ключами прив'язане до FreeBSD (не переносиме на Linux/інші OpenZFS)
+
+**Розмітка розділів:**
+```
+[boot] [ESP*] [swap (GELI)] [ZFS на GELI-провайдері]
+```
+
+**Ключові кроки реалізації:**
+1. Нова опція: `-E geli`
+2. Після створення ZFS-розділу під'єднати GELI до створення zpool:
+   - `geli init -bg -s 4096 /dev/gpt/system-<label>`
+   - `geli attach /dev/gpt/system-<label>`
+3. Створити zpool на `/dev/gpt/system-<label>.eli` замість сирого розділу
+4. Додати до `loader.conf`:
+   - `geom_eli_load="YES"`
+   - `vfs.root.mountfrom="zfs:poolname"`
+5. Додати до `/etc/rc.conf`:
+   - `geli_devices="gpt/system-<label>"`
+   - Або обробляти через `geli_autodetach`
+6. Шифрування swap: `geli onetime -s 4096 /dev/gpt/swap-<label>`
+   - Додати суфікс `.eli` у fstab
+
+### Варіант B: Рідне шифрування ZFS (OpenZFS 2.0+)
+
+Шифрування на рівні окремих datasets всередині ZFS. Потребує FreeBSD 13.0+.
+
+**Переваги:**
+- Гранулярність на рівні dataset (шифрувати лише потрібне)
+- `zfs send -w` надсилає зашифровані дані (без розшифровування)
+- Переноситься між платформами OpenZFS (Linux, FreeBSD)
+- Менші накладні витрати, ніж у GELI
+
+**Недоліки:**
+- Метадані ZFS (імена datasets, розміри) **НЕ** шифруються
+- `loader.efi` не вміє розблокувати зашифровані datasets — потрібна незашифрована boot pool/dataset
+- Потрібна окрема незашифрована область `/boot`
+- Лише FreeBSD 13.0+
+
+**Розмітка розділів:**
+```
+[boot] [ESP*] [swap] [ZFS]
+  └── poolname (незашифрований)
+       ├── poolname/bootpool (незашифрований, mountpoint=/boot)
+       └── poolname/encrypted (зашифрований, encryptionroot)
+            ├── poolname/encrypted/root (mountpoint=/)
+            ├── poolname/encrypted/usr
+            ├── poolname/encrypted/var
+            └── ...
+```
+
+**Ключові кроки реалізації:**
+1. Нова опція: `-E native`
+2. Створити zpool як зазвичай (незашифрований кореневий dataset)
+3. Створити незашифрований boot dataset:
+   - `zfs create -o mountpoint=/boot poolname/boot`
+4. Створити зашифрований батьківський dataset:
+   - `zfs create -o encryption=aes-256-gcm -o keylocation=prompt -o keyformat=passphrase poolname/encrypted`
+5. Створити дочірні datasets під зашифрованим батьківським (вони успадкують шифрування)
+6. Модифікувати ZFS skeleton, щоб використовувати префікс `poolname/encrypted/`
+7. Додати до `/etc/rc.conf`:
+   - Обробити завантаження ключа під час старту (запит або файл-ключ)
+
+## Нова CLI-опція
+
+```
+-E <encryption_mode>    Режим шифрування: none (за замовчуванням), geli, native
+```
+
+## Спільні вимоги (для обох методів)
+
+- [ ] Запит пароля під час встановлення (інтерактивно) або прийняття через опцію `-P`
+- [ ] Шифрування swap (GELI onetime для обох методів)
+- [ ] Оновити `loader.conf` потрібними модулями
+- [ ] Оновити `check_size()` з урахуванням накладних витрат GELI (~0.5% + метадані)
+- [ ] Тестова матриця: BIOS/UEFI/hybrid x GELI/native x single/mirror/raidz
+- [ ] Документація у README-файлах (EN, RU, UK)
+
+## ESP та шифрування
+
+Для UEFI-завантаження з шифруванням:
+- ESP залишається **незашифрованим** (FAT32 з `loader.efi`) — цього вимагає специфікація UEFI
+- GELI: `loader.efi` запитує пароль перед монтуванням кореневого ZFS
+- Native: `loader.efi` завантажує ядро з незашифрованого boot dataset, потім `rc.d`-скрипти розблоковують зашифровані datasets
+
+## Посилання
+
+- [FreeBSD Handbook: Disk Encryption](https://docs.freebsd.org/en/books/handbook/disks/#disks-encrypting)
+- [geli(8)](https://man.freebsd.org/cgi/man.cgi?geli(8))
+- [OpenZFS Native Encryption](https://openzfs.github.io/openzfs-docs/Getting%20Started/Ubuntu/Encryption.html)
+- [FreeBSD Wiki: Root on ZFS with GELI](https://wiki.freebsd.org/RootOnZFS/GPTZFSBoot)
+- [FreeBSD 13 Release Notes: OpenZFS 2.0](https://www.freebsd.org/releases/13.0R/relnotes/)

--- a/gozfs.sh
+++ b/gozfs.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-# Current Version: 1.57
+# Current Version: 1.58
 
 # original script by Philipp Wuensche at http://anonsvn.h3q.com/s/gpt-zfsroot.sh
 # This script is considered beer ware (http://en.wikipedia.org/wiki/Beerware)

--- a/gozfs.sh
+++ b/gozfs.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-# Current Version: 1.58
+# Current Version: 1.59
 
 # original script by Philipp Wuensche at http://anonsvn.h3q.com/s/gpt-zfsroot.sh
 # This script is considered beer ware (http://en.wikipedia.org/wiki/Beerware)
@@ -63,12 +63,16 @@ memdisknumber=10
 
 usage="Usage: $0 -p <geom_provider> -s <swap_partition_size> -S <zfs_partition_size> -n <zpoolname> -f <ftphost>
 [ -m <zpool-raidmode> -d <distribution_dir> -D <destination_dir> -M <size_memory_disk> -o <offset_end_disk> -a <ashift_disk>
--B <boot_mode> -P <new_password> -t <timezone> -k <url_ssh_key_file> -K <url_ssh_key_dir>
+-B <boot_mode> -E <encryption_mode> -P <new_password> -t <timezone> -k <url_ssh_key_file> -K <url_ssh_key_dir>
 -z <file_zfs_skeleton> -Z <url_file_zfs_skeleton> -x ]
 [ -g <gateway> [-i <iface>] -I <IP_address/mask> ]
 
 boot_mode: auto (default), bios, uefi, hybrid
 ashift_disk: 512b, 4k (default), 8k
+encryption_mode: none (default), native
+  When 'native': creates an extra encrypted dataset <poolname>/encrypted
+  with aes-256-gcm. Passphrase is read from \$ZFS_ENCRYPT_PASSPHRASE env var
+  or prompted interactively. Unlocked at boot via the zfskeys rc service.
 -x: also install debug distribution sets (base-dbg, lib32-dbg, kernel-dbg)"
 
 exerr() {
@@ -76,7 +80,7 @@ exerr() {
 	exit 1
 }
 
-while getopts p:P:s:S:n:h:f:m:M:o:d:D:t:g:i:I:a:B:z:Z:k:K:x arg; do
+while getopts p:P:s:S:n:h:f:m:M:o:d:D:t:g:i:I:a:B:E:z:Z:k:K:x arg; do
 	case ${arg} in
 	p) provider="$provider ${OPTARG}" ;;
 	P) password=${OPTARG} ;;
@@ -96,6 +100,7 @@ while getopts p:P:s:S:n:h:f:m:M:o:d:D:t:g:i:I:a:B:z:Z:k:K:x arg; do
 	I) ip_address=${OPTARG} ;;
 	a) ashift=${OPTARG} ;;
 	B) boot_mode=${OPTARG} ;;
+	E) encryption_mode=${OPTARG} ;;
 	z) file_zfs_skeleton=${OPTARG} ;;
 	Z) url_file_zfs_skeleton=${OPTARG} ;;
 	k) ssh_key_file="${ssh_key_file} ${OPTARG}" ;;
@@ -146,6 +151,35 @@ case "$ashift" in
 		;;
 	*) exerr "Invalid ashift: $ashift. Use 512b, 4k, or 8k." ;;
 esac
+
+# Encryption mode (default: off)
+[ -z "$encryption_mode" ] && encryption_mode="none"
+case "$encryption_mode" in
+	none|native) ;;
+	*) exerr "Invalid encryption mode: $encryption_mode. Use none or native." ;;
+esac
+
+encrypt_keyfile=""
+if [ "$encryption_mode" = "native" ]; then
+	encrypt_keyfile=$(mktemp /tmp/zfs_passphrase.XXXXXX) || exerr "Cannot create passphrase tempfile"
+	chmod 600 "$encrypt_keyfile"
+	if [ -n "$ZFS_ENCRYPT_PASSPHRASE" ]; then
+		printf '%s' "$ZFS_ENCRYPT_PASSPHRASE" > "$encrypt_keyfile"
+	else
+		printf 'Enter ZFS encryption passphrase (>=8 chars): ' >&2
+		stty -echo 2>/dev/null
+		IFS= read -r encrypt_passphrase
+		stty echo 2>/dev/null
+		echo >&2
+		if [ "${#encrypt_passphrase}" -lt 8 ]; then
+			rm -f "$encrypt_keyfile"
+			exerr "Passphrase too short (need >=8 chars)"
+		fi
+		printf '%s' "$encrypt_passphrase" > "$encrypt_keyfile"
+		unset encrypt_passphrase
+	fi
+fi
+
 [ -z "$offset" ] && offset="2048"	# remainder at the end of the disc, 1 MB
 									# 1 MB approximately for every full and partial 1 TB of disk capacity.
 destdir=${destdir:-/mnt}
@@ -502,6 +536,23 @@ zfs create                      -o exec=on      -o setuid=off   $poolname/var/tm
 
 fi
 
+# Optional: create encrypted dataset (ZFS native encryption, OpenZFS 2.0+)
+if [ "$encryption_mode" = "native" ]; then
+	echo "Creating encrypted dataset $poolname/encrypted (aes-256-gcm)"
+	zfs create \
+		-o encryption=aes-256-gcm \
+		-o keyformat=passphrase \
+		-o keylocation=file://"$encrypt_keyfile" \
+		-o mountpoint=/encrypted \
+		"$poolname/encrypted" || {
+			rm -f "$encrypt_keyfile"
+			exerr "Failed to create encrypted dataset (does the pool support feature@encryption?)"
+		}
+	# switch to prompt-on-boot so no plaintext key remains on disk
+	zfs set keylocation=prompt "$poolname/encrypted"
+	rm -f "$encrypt_keyfile"
+fi
+
 zpool export $poolname
 zpool import -f -d /dev/gpt/ -o altroot=$destdir -o cachefile=/tmp/zpool.cache $poolname
 
@@ -566,6 +617,11 @@ sshd_enable="YES"
 sshd_flags="-oPort=22 -oCompression=yes -oPermitRootLogin=yes -oPasswordAuthentication=yes -oUseDNS=no"
 dumpdev="AUTO"
 EOF
+
+# enable on-boot ZFS key prompt for encrypted datasets
+if [ "$encryption_mode" = "native" ]; then
+	echo 'zfskeys_enable="YES"' >>$destdir/etc/rc.conf
+fi
 
 # apply DNS settings
 [ -n "$nameserver" ] && {

--- a/gozfs.sh
+++ b/gozfs.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-# Current Version: 1.59
+# Current Version: 1.60
 
 # original script by Philipp Wuensche at http://anonsvn.h3q.com/s/gpt-zfsroot.sh
 # This script is considered beer ware (http://en.wikipedia.org/wiki/Beerware)

--- a/gozfs.sh
+++ b/gozfs.sh
@@ -71,8 +71,11 @@ boot_mode: auto (default), bios, uefi, hybrid
 ashift_disk: 512b, 4k (default), 8k
 encryption_mode: none (default), native
   When 'native': creates an extra encrypted dataset <poolname>/encrypted
-  with aes-256-gcm. Passphrase is read from \$ZFS_ENCRYPT_PASSPHRASE env var
-  or prompted interactively. Unlocked at boot via the zfskeys rc service.
+  with aes-256-gcm. Passphrase source (in priority order):
+    -e <file>  --  read passphrase from file (recommended; avoids shell quoting)
+    \$ZFS_ENCRYPT_PASSPHRASE env var
+    interactive prompt
+  Unlocked at boot via the zfskeys rc service.
 -x: also install debug distribution sets (base-dbg, lib32-dbg, kernel-dbg)"
 
 exerr() {
@@ -80,7 +83,7 @@ exerr() {
 	exit 1
 }
 
-while getopts p:P:s:S:n:h:f:m:M:o:d:D:t:g:i:I:a:B:E:z:Z:k:K:x arg; do
+while getopts p:P:s:S:n:h:f:m:M:o:d:D:t:g:i:I:a:B:E:e:z:Z:k:K:x arg; do
 	case ${arg} in
 	p) provider="$provider ${OPTARG}" ;;
 	P) password=${OPTARG} ;;
@@ -101,6 +104,7 @@ while getopts p:P:s:S:n:h:f:m:M:o:d:D:t:g:i:I:a:B:E:z:Z:k:K:x arg; do
 	a) ashift=${OPTARG} ;;
 	B) boot_mode=${OPTARG} ;;
 	E) encryption_mode=${OPTARG} ;;
+	e) encrypt_passphrase_file=${OPTARG} ;;
 	z) file_zfs_skeleton=${OPTARG} ;;
 	Z) url_file_zfs_skeleton=${OPTARG} ;;
 	k) ssh_key_file="${ssh_key_file} ${OPTARG}" ;;
@@ -163,7 +167,15 @@ encrypt_keyfile=""
 if [ "$encryption_mode" = "native" ]; then
 	encrypt_keyfile=$(mktemp /tmp/zfs_passphrase.XXXXXX) || exerr "Cannot create passphrase tempfile"
 	chmod 600 "$encrypt_keyfile"
-	if [ -n "$ZFS_ENCRYPT_PASSPHRASE" ]; then
+	if [ -n "$encrypt_passphrase_file" ]; then
+		# Most shell-portable path (csh-friendly, no quoting hazards).
+		[ -r "$encrypt_passphrase_file" ] || {
+			rm -f "$encrypt_keyfile"
+			exerr "Passphrase file not readable: $encrypt_passphrase_file"
+		}
+		# Strip any trailing newline so 'echo passphrase > file' just works.
+		awk 'NR==1{printf "%s", $0; exit}' "$encrypt_passphrase_file" > "$encrypt_keyfile"
+	elif [ -n "$ZFS_ENCRYPT_PASSPHRASE" ]; then
 		printf '%s' "$ZFS_ENCRYPT_PASSPHRASE" > "$encrypt_keyfile"
 	else
 		printf 'Enter ZFS encryption passphrase (>=8 chars): ' >&2


### PR DESCRIPTION
## Summary

- Adds optional **ZFS native encryption** to `gozfs.sh` via a new `-E none|native` flag (default `none` — no behavior change for existing users). Implements Option B from `TODO.ZFS encryption.md`.
- Adds **Ukrainian translation** of `TODO.ZFS encryption.md` (`TODO.ZFS encryption.UK.md`).
- Bumps script version to **1.60**.

## `-E native` behavior

When enabled, the script creates an extra dataset `<poolname>/encrypted` (`aes-256-gcm`, mounted at `/encrypted`), and adds `zfskeys_enable="YES"` to the new system's `rc.conf` so the passphrase is prompted at boot via the `zfskeys` rc service. No plaintext key is left on disk: a temp keyfile is removed immediately after `keylocation` is switched to `prompt`.

## Passphrase sources (priority)

1. `-e <file>` — read from a file (csh/tcsh-friendly, avoids shell-quoting hazards with `!`, `*`, `~`).
2. `$ZFS_ENCRYPT_PASSPHRASE` — env var.
3. Interactive prompt — minimum 8 chars, echo disabled via `stty`.

## Examples

```sh
# safest (any shell)
echo 'secret123' > /tmp/zfs.key
sh gozfs.sh -p ada0 -n tank -E native -e /tmp/zfs.key

# scripted
env ZFS_ENCRYPT_PASSPHRASE='secret' sh gozfs.sh -p ada0 -n tank -E native

# interactive
sh gozfs.sh -p ada0 -n tank -E native
```

## Test plan

- [ ] `-E none` (default) — verify install is byte-identical to pre-PR
- [ ] `-E native -e /path/to/key` — verify `/encrypted` dataset created, `zfskeys` enabled, no keyfile leftovers
- [ ] `-E native` with `ZFS_ENCRYPT_PASSPHRASE` env — verify env-var path
- [ ] `-E native` interactive — verify prompt + length check
- [ ] First reboot — verify zfskeys service prompts and unlocks `/encrypted`
- [ ] `-E bogus` — verify rejection
- [ ] csh/tcsh: `-e` works without quoting issues for passphrases containing `!`

https://claude.ai/code/session_011YpUdfuGust7d5oLW6unep

---
_Generated by [Claude Code](https://claude.ai/code/session_011YpUdfuGust7d5oLW6unep)_